### PR TITLE
Single unique index insert-only deadlock

### DIFF
--- a/examples/deadlocks/unique_indexes/1.single_index.rb
+++ b/examples/deadlocks/unique_indexes/1.single_index.rb
@@ -1,0 +1,21 @@
+# Unique index could be dangerous when multiple transactions
+# attempt to write same values concurrently.
+#
+# More info: https://rcoh.svbtle.com/postgres-unique-constraints-can-cause-deadlock
+
+gana do |tx1, tx2|
+  table = new_table :lol do
+    primary_key :id
+    column :key, :text, unique: true
+  end
+
+  [tx1, tx2].each(&:begin_transaction)
+
+  tx1.sync { table.insert(key: 'foo') }
+  tx2.sync { table.insert(key: 'bar') }
+
+  tx1.exec { table.insert(key: 'bar') }
+  tx2.exec { table.insert(key: 'foo') }
+
+  [tx1, tx2].each(&:commit_transaction)
+end


### PR DESCRIPTION
```console
$ bundle exec gana examples/deadlocks/unique_indexes/1.single_index.rb
✔ (T1) BEGIN (0.008831s)
✔ (T2) BEGIN (0.008825s)
✔ (T1) SELECT pg_attribute.attname AS pk FROM pg_class, pg_attribute, pg_index, pg_namespace WHERE pg_class.oid = pg_attribute.attrelid AND pg_class.relnamespace = pg_namespace.oi
d AND pg_class.oid = pg_index.indrelid AND pg_index.indkey[0] = pg_attribute.attnum AND pg_index.indisprimary = 't' AND pg_class.oid = CAST(CAST('"lol_eb28e9"' AS regclass) AS oid
✔ (T1) INSERT INTO "lol_eb28e9" ("key") VALUES ('foo') RETURNING "id" (0.000963s)
✔ (T2) INSERT INTO "lol_eb28e9" ("key") VALUES ('bar') RETURNING "id" (0.002572s)
✘ (T1) INSERT INTO "lol_eb28e9" ("key") VALUES ('bar') RETURNING "id"
✔ (T2) INSERT INTO "lol_eb28e9" ("key") VALUES ('foo') RETURNING "id" (1.021329s)
✔ (T1) ROLLBACK (0.000305s)
✔ (T2) COMMIT (0.001111s)
✘ (T1) #<Sequel::SerializationFailure: PG::TRDeadlockDetected: ERROR:  deadlock detected
DETAIL:  Process 13804 waits for ShareLock on transaction 415133; blocked by process 13805.
Process 13805 waits for ShareLock on transaction 415135; blocked by process 13804.
```